### PR TITLE
[fix] phonegap / gulp serve

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -12,7 +12,7 @@
     	
     }
     </script>
-    <script type="text/javascript" src="phonegap.js"></script>
+    <script type="text/javascript" src="cordova.js"></script>
     <script type="text/javascript" src="js/bundle.js"></script>
 </head>
 <body class="page">


### PR DESCRIPTION
"phonegap.js" should be renamed to "cordova.js", since this file is the one which is expected. changing this will lead to a working phonegap developer app preview
